### PR TITLE
Fixed incorrect use of 'self' variable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,43 +5,39 @@ var inherits = require('util').inherits;
 var CONNECTION = 'http://scorebot2.hltv.org';
 var PORT = 10022;
 
-var self;
-
 function Livescore(options) {
-    self = this;
-
     options = options || {};
 
-    self.connected = false;
-    self.started = false;
+    this.connected = false;
+    this.started = false;
 
-    self.listid = options.listid || null;
-    self.url = options.url || CONNECTION;
-    self.port = options.port || PORT;
+    this.listid = options.listid || null;
+    this.url = options.url || CONNECTION;
+    this.port = options.port || PORT;
 
-    self.socket = io(self.url + ':' + self.port);
+    this.socket = io(this.url + ':' + this.port);
 
-    self.time = 0;
-    self.map;
-    self.interval;
+    this.time = 0;
+    this.map;
+    this.interval;
 
-    self.scoreboard;
+    this.scoreboard;
 
-    self.players = {};
-    self.teams = {};
+    this.players = {};
+    this.teams = {};
 
-    self.kills = 0;
-    self.knifeKills = 0;
+    this.kills = 0;
+    this.knifeKills = 0;
 
-    self._lastLog;
+    this._lastLog;
 
-    self.options = {};
+    this.options = {};
 
-    self.options[Livescore.Enums.EOption['ROUND_TIME']] = options.roundTime || 115; // 105 before update
-    self.options[Livescore.Enums.EOption['BOMB_TIME']] = options.bombTime || 40; // 35 before update
-    self.options[Livescore.Enums.EOption['FREEZE_TIME']] = options.freezeTime || 15;
+    this.options[Livescore.Enums.EOption['ROUND_TIME']] = options.roundTime || 115; // 105 before update
+    this.options[Livescore.Enums.EOption['BOMB_TIME']] = options.bombTime || 40; // 35 before update
+    this.options[Livescore.Enums.EOption['FREEZE_TIME']] = options.freezeTime || 15;
 
-    self.socket.on('connect', self._onConnect);
+    this.socket.on('connect', this._onConnect.bind(this)));
 }
 
 inherits(Livescore, EE);
@@ -57,10 +53,10 @@ Livescore.prototype.start = function(options, callback) {
 
     options = options || {};
 
-    self.listid = options.listid || self.listid;
+    this.listid = options.listid || this.listid;
 
-    if (self.connected) {
-        self.socket.emit('readyForMatch', self.listid);
+    if (this.connected) {
+        this.socket.emit('readyForMatch', this.listid);
 
         if (callback) {
             callback(null);
@@ -71,49 +67,49 @@ Livescore.prototype.start = function(options, callback) {
 };
 
 Livescore.prototype.disconnect = function() {
-    self.connected = false;
-    self.socket.disconnect();
+    this.connected = false;
+    this.socket.disconnect();
 };
 
 Livescore.prototype.getPlayers = function(callback) {
-    callback(self.players);
+    callback(this.players);
 };
 
 Livescore.prototype.getTeams = function(callback) {
-    callback(self.teams);
+    callback(this.teams);
 };
 
 Livescore.prototype.setTime = function(time) {
-    clearInterval(self.interval);
+    clearInterval(this.interval);
 
-    self.time = time;
-    self.interval = setInterval(() => {
-        self.time = self.time - 1;
-        self.emit('time', self.time);
+    this.time = time;
+    this.interval = setInterval(() => {
+        this.time = this.time - 1;
+        this.emit('time', this.time);
     }, 1000);
 };
 
 Livescore.prototype.getTime = function(callback) {
-    callback(self.time);
+    callback(this.time);
 };
 
 Livescore.prototype._onConnect = function() {
-    if (!self.connected) {
-        self.connected = true;
+    if (!this.connected) {
+        this.connected = true;
 
-        self.socket.on('log', self._onLog);
-        self.socket.on('scoreboard', self._onScoreboard);
+        this.socket.on('log', this._onLog.bind(this));
+        this.socket.on('scoreboard', this._onScoreboard.bind(this));
 
-        self.emit('connected');
+        this.emit('connected');
     }
 
-    if (self.listid) {
-        self.socket.emit('readyForMatch', self.listid);
+    if (this.listid) {
+        this.socket.emit('readyForMatch', this.listid);
     }
 };
 
 Livescore.prototype._onReconnect = function() {
-    self.socket.emit('readyForMatch', self.listid);
+    this.socket.emit('readyForMatch', this.listid);
 };
 
 Livescore.prototype._onLog = function(logs) {
@@ -122,19 +118,19 @@ Livescore.prototype._onLog = function(logs) {
     } catch (err) {
         logs = null;
 
-        self.emit('debug', err);
+        this.emit('debug', err);
     }
 
-    if (logs && logs !== self._lastLog) {
-        self.emit('log', logs);
+    if (logs && logs !== this._lastLog) {
+        this.emit('log', logs);
 
-        self.getPlayers((players) => {
+        this.getPlayers((players) => {
             if (Object.keys(players).length && logs) {
                 logs.forEach((log) => {
                     var event;
 
                     for (event in log) {
-                        self.emit('debug', 'received event: ' + event);
+                        this.emit('debug', 'received event: ' + event);
 
                         switch (event) {
                             case 'Kill':
@@ -149,10 +145,10 @@ Livescore.prototype._onLog = function(logs) {
                             case 'MatchStarted':
                             case 'Restart':
                             case 'Suicide':
-                                self['_on' + event](log[event]);
+                                this['_on' + event](log[event]);
                                 break;
                             default:
-                                self.emit('debug', 'unrecognized event: ' + event);
+                                this.emit('debug', 'unrecognized event: ' + event);
                                 break;
                         }
                     }
@@ -160,31 +156,31 @@ Livescore.prototype._onLog = function(logs) {
             }
         });
 
-        self._lastLog = logs;
+        this._lastLog = logs;
     }
 };
 
 Livescore.prototype._onScoreboard = function(event) {
-    if (!self.started) {
-        self.started = true;
-        self.emit('started');
+    if (!this.started) {
+        this.started = true;
+        this.emit('started');
     }
 
     updateGame(event);
 
-    self.getTeams((teams) => {
+    this.getTeams((teams) => {
         var scoreboard = new Livescore.Classes.Scoreboard(event);
 
         scoreboard.teams[Livescore.Enums.ESide['TERRORIST']] = teams[Livescore.Enums.ESide['TERRORIST']];
         scoreboard.teams[Livescore.Enums.ESide['COUNTERTERRORIST']] = teams[Livescore.Enums.ESide['COUNTERTERRORIST']];
 
-        self.emit('scoreboard', scoreboard);
+        this.emit('scoreboard', scoreboard);
     });
 };
 
 Livescore.prototype._onKill = function(event) {
-    self.getPlayers((players) => {
-        self.emit('kill', {
+    this.getPlayers((players) => {
+        this.emit('kill', {
             killer: players[event.killerName],
             victim: players[event.victimName],
             weapon: event.weapon,
@@ -192,103 +188,103 @@ Livescore.prototype._onKill = function(event) {
         });
     });
 
-    self.kills++;
+    this.kills++;
     if (event.weapon.indexOf('knife') > -1 || event.weapon.indexOf('bayonet') > -1) {
-        self.knifeKills++;
+        this.knifeKills++;
     }
 };
 
 Livescore.prototype._onSuicide = function(event) {
-    self.getPlayers((players) => {
-        self.emit('suicide', {
+    this.getPlayers((players) => {
+        this.emit('suicide', {
             player: players[event.playerName]
         });
     });
 };
 
 Livescore.prototype._onBombPlanted = function(event) {
-    self.setTime(self.options[Livescore.Enums.EOption['BOMB_TIME']]);
+    this.setTime(this.options[Livescore.Enums.EOption['BOMB_TIME']]);
 
-    self.getPlayers((players) => {
-        self.emit('bombPlanted', {
+    this.getPlayers((players) => {
+        this.emit('bombPlanted', {
             player: players[event.playerName]
         });
     });
 };
 
 Livescore.prototype._onBombDefused = function(event) {
-    self.getPlayers((players) => {
-        self.emit('bombDefused', {
+    this.getPlayers((players) => {
+        this.emit('bombDefused', {
             player: players[event.playerName]
         });
     });
 };
 
 Livescore.prototype._onMatchStarted = function(event) {
-    self.emit('matchStart', event);
+    this.emit('matchStart', event);
 };
 
 Livescore.prototype._onRoundStart = function() {
-    self.setTime(self.options[Livescore.Enums.EOption["ROUND_TIME"]]);
-    self.emit('roundStart', {
-        round: self.scoreboard.currentRound
+    this.setTime(this.options[Livescore.Enums.EOption["ROUND_TIME"]]);
+    this.emit('roundStart', {
+        round: this.scoreboard.currentRound
     });
 
-    self.kills = 0;
-    self.knifeKills = 0;
+    this.kills = 0;
+    this.knifeKills = 0;
 };
 
 Livescore.prototype._onRoundEnd = function(event) {
     var winner = Livescore.Enums.ESide[event.winner === 'TERRORIST' ? 'TERRORIST' : 'COUNTERTERRORIST'];
 
-    self.setTime(self.options[Livescore.Enums.EOption["FREEZE_TIME"]]);
+    this.setTime(this.options[Livescore.Enums.EOption["FREEZE_TIME"]]);
 
-    self.getTeams((teams) => {
+    this.getTeams((teams) => {
         if (Object.keys(teams).length) {
             teams[Livescore.Enums.ESide['TERRORIST']].score = event.terroristScore;
             teams[Livescore.Enums.ESide['COUNTERTERRORIST']].score = event.counterTerroristScore;
 
             // If at least 80% of the kills are knife kills, count it as a knife
             // round. Sometimes players will have pistols on knife rounds and
-            // kill teammates after the round is over, so self takes that into
+            // kill teammates after the round is over, so this takes that into
             // account.
-            self.emit('roundEnd', {
+            this.emit('roundEnd', {
                 teams: teams,
                 winner: teams[winner],
                 roundType: Livescore.Enums.ERoundType[event.winType],
-                knifeRound: (self.knifeKills/self.kills) >= 0.8
+                knifeRound: (this.knifeKills/this.kills) >= 0.8
             });
         }
     });
 };
 
 Livescore.prototype._onPlayerJoin = function(event) {
-    self.emit('playerJoin', {
+    this.emit('playerJoin', {
         playerName: event.playerName
     });
 };
 
 Livescore.prototype._onPlayerQuit = function(event) {
-    self.getPlayers((players) => {
-        self.emit('playerQuit', {
+    this.getPlayers((players) => {
+        this.emit('playerQuit', {
             player: players[event.playerName]
         });
     });
 };
 
 Livescore.prototype._onRestart = function() {
-    self.emit('restart');
+    this.emit('restart');
 };
 
 Livescore.prototype._onMapChange = function(event) {
-    self.emit('mapChange', event);
+    this.emit('mapChange', event);
 };
 
 function updateGame(scoreboard) {
     var tPlayers = [];
     var ctPlayers = [];
 
-    self.teams[Livescore.Enums.ESide['TERRORIST']] = new Livescore.Classes.Team({
+    this.teams[Livescore.Enums.ESide['TERRORIST']] = new Livescore.Classes.Team({
         name: scoreboard.terroristTeamName,
         id: scoreboard.tTeamId,
         score: scoreboard.terroristScore,
@@ -297,7 +293,7 @@ function updateGame(scoreboard) {
         history: scoreboard.terroristMatchHistory
     });
 
-    self.teams[Livescore.Enums.ESide['COUNTERTERRORIST']] = new Livescore.Classes.Team({
+    this.teams[Livescore.Enums.ESide['COUNTERTERRORIST']] = new Livescore.Classes.Team({
         name: scoreboard.ctTeamName,
         id: scoreboard.ctTeamId,
         score: scoreboard.counterTerroristScore,
@@ -306,12 +302,12 @@ function updateGame(scoreboard) {
         history: scoreboard.ctMatchHistory
     });
 
-    self.getTeams((teams) => {
+    this.getTeams((teams) => {
         scoreboard.TERRORIST.forEach((pl) => {
             var player = new Livescore.Classes.Player(pl);
             player.team = teams[Livescore.Enums.ESide['TERRORIST']];
 
-            self.players[player.name] = player;
+            this.players[player.name] = player;
             tPlayers.push(player);
         });
 
@@ -319,12 +315,12 @@ function updateGame(scoreboard) {
             var player = new Livescore.Classes.Player(pl);
             player.team = teams[Livescore.Enums.ESide['COUNTERTERRORIST']];
 
-            self.players[player.name] = player;
+            this.players[player.name] = player;
             ctPlayers.push(player);
         });
     });
 
-    self.scoreboard = scoreboard;
+    this.scoreboard = scoreboard;
 }
 
 module.exports = Livescore;

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ function Livescore(options) {
     this.options[Livescore.Enums.EOption['BOMB_TIME']] = options.bombTime || 40; // 35 before update
     this.options[Livescore.Enums.EOption['FREEZE_TIME']] = options.freezeTime || 15;
 
-    this.socket.on('connect', this._onConnect.bind(this)));
+    this.socket.on('connect', this._onConnect.bind(this));
 }
 
 inherits(Livescore, EE);


### PR DESCRIPTION
Fix for the issue: https://github.com/andrewda/hltv-livescore/issues/33

"self" variable was incorrectly used when there are multiple instances of livescore module.
When new instance of `livescore` is created, `self` variable will be pointing to the latest instance.